### PR TITLE
Fix Wikipedia link

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -58,7 +58,7 @@
 		<dc:source>https://archive.org/details/panmichaelhistor00sienuoft</dc:source>
 		<meta property="se:word-count">204811</meta>
 		<meta property="se:reading-ease.flesch">68.91</meta>
-		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Fire_in_the_Steppe</meta>
+		<meta property="se:url.encyclopedia.wikipedia">https://en.wikipedia.org/wiki/Pan_Michael</meta>
 		<meta property="se:url.vcs.github">https://github.com/standardebooks/henryk-sienkiewicz_pan-michael_jeremiah-curtin</meta>
 		<dc:creator id="author">Henryk Sienkiewicz</dc:creator>
 		<meta property="file-as" refines="#author">Sienkiewicz, Henryk</meta>


### PR DESCRIPTION
The Wikipedia link that is currently in this ebook's metadata goes to a page that redirects to the page for this novel. This PR updates the Wikipedia link to the current address to avoid that intermediate redirection step.